### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you also like this module and want to thank, please rate this repository with
 
    ```sh
    cd MMM-Jast
-   npm install --omit=dev
+   npm install
    ```
 
 3. Add the module configuration into the `MagicMirror/config/config.js` file (sample configuration):

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you also like this module and want to thank, please rate this repository with
 
    ```sh
    cd MMM-Jast
-   npm install --only=production
+   npm install --omit=dev
    ```
 
 3. Add the module configuration into the `MagicMirror/config/config.js` file (sample configuration):


### PR DESCRIPTION
I don't think anyone uses npm under version 8 to run MagicMirror anymore.

> In version 8.x and above use --omit=dev flag
> ....
> If you use 6.x or an earlier version, you need to use the --only=prod flag instead.

Source: https://stackoverflow.com/a/9276112