### PR TITLE
Added default MagicMirror table layout with default size small

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you also like this module and want to thank, please rate this repository with
     maxWidth: "100%",
     numberDecimalsPercentages: 1,
     numberDecimalsValues: 2,
-    displayMode: "vertical", // One of ["none", "vertical", "horizontal", "table"]
+    displayMode: "vertical", // One of ["none", "vertical", "horizontal", "table", "default-table"]
     showColors: true,
     showCurrency: true,
     showChangePercent: true,
@@ -113,9 +113,9 @@ If you also like this module and want to thank, please rate this repository with
 ### Options
 
 | Option                            | Description                                                                                                                                                                                  |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `currencyStyle`                   | Style of currency. <br><br>**Type:** `String` <br>**Allowed values:** `"code"` (EUR), `"symbol"` (€) or `"name"` (Euro)<br> **Default value:** `code`                                        |
-| `displayMode`                     | Display mode for ticker. <br><br>**Type:** `String`<br>**Allowed Values:** `"none"`, `"vertical"`, `"horizontal"` or `"table"` <br>**Default value:** `"vertical"`                           |
+| `displayMode`                     | Display mode for ticker. <br><br>**Type:** `String`<br>**Allowed Values:** `"none"`, `"vertical"`, `"horizontal"`, `"table"` or `"default-table"` <br>**Default value:** `"vertical"`        |
 | `fadeSpeedInSeconds`              | Animation speed for ticker. <br><br>**Type:** `Number`<br> **Default value:** `3.5`                                                                                                          |
 | `lastUpdateFormat`                | Define dateformat, if the last update should be displayed. <br><br>**Type:** `String`<br> **Default value:** `"HH:mm"`                                                                       |
 | `locale`                          | Option to override the global/system locale for value formatting. <br><br>**Type:** `String`<br> **Default value:** `undefined` (system locale)                                              |

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -7,7 +7,7 @@ export type Config = {
   maxWidth: string
   numberDecimalsPercentages: number
   numberDecimalsValues: number
-  displayMode: 'vertical' | 'horizontal' | 'none' | 'table'
+  displayMode: 'vertical' | 'horizontal' | 'none' | 'table' | 'default-table'
   scroll?: 'vertical' | 'horizontal' | 'none' | 'table'
   showCurrency: boolean
   showColors: boolean

--- a/templates/DefaultTableStockList.njk
+++ b/templates/DefaultTableStockList.njk
@@ -1,0 +1,26 @@
+{% macro render() %}
+<table class="{{ config.tableClass }}">
+  {% for stock in stocks %}
+  <tr>
+    <td class="bright"><span>{{ utils.getStockName(stock) }}</span></td>
+    <td>
+      {% if utils.getStockChange(stock) > 0 %}
+      {% set colorStyle = "green" %}
+      {% elif utils.getStockChange(stock) < 0 %}
+      {% set colorStyle = "red" %}
+      {% else %}
+      {% set colorStyle = "" %}
+      {% endif %}
+      <span>{{ utils.getCurrentValueAsString(stock, config) }}</span>
+    </td>
+    <td>
+      <span>
+        <span>
+          <span style="{% if colorStyle != "" %} color:{{ colorStyle }}{%endif%}">{% if colorStyle == "green" %}+{%endif%}{{ utils.getStockChangePercentAsString(stock, config) }}</span>
+        </span>
+      </span>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endmacro %}

--- a/templates/MMM-Jast.njk
+++ b/templates/MMM-Jast.njk
@@ -1,17 +1,22 @@
 {% import "templates/VerticalStockList.njk" as verticalStockList with context %}
 {% import "templates/HorizontalStockList.njk" as horizontalStockList with context %}
 {% import "templates/TableStockList.njk" as tableStockList with context %}
+{% import "templates/DefaultTableStockList.njk" as defaultTableStockList with context %}
 {% if stocks.length > 0 %}
-  <div class="normal medium jast-wrapper {{ config.displayMode }}{% if not config.showColors %} monochrome{% endif %}" style="max-width: {{config.maxWidth}};">
-    {% if config.displayMode == "horizontal" %}
-      {{ horizontalStockList.render() }}
-      {{ horizontalStockList.render("2") }}
-    {% elif config.displayMode == "table" %}
-      {{ tableStockList.render() }}
-    {% else %}
-      {{ verticalStockList.render() }}
-    {% endif %}
-  </div>
+  {% if config.displayMode == "default-table" %}
+    {{ defaultTableStockList.render() }}
+  {% else %}
+    <div class="normal medium jast-wrapper {{ config.displayMode }}{% if not config.showColors %} monochrome{% endif %}" style="max-width: {{config.maxWidth}};">
+      {% if config.displayMode == "horizontal" %}
+        {{ horizontalStockList.render() }}
+        {{ horizontalStockList.render("2") }}
+      {% elif config.displayMode == "table" %}
+        {{ tableStockList.render() }}
+      {% else %}
+        {{ verticalStockList.render() }}
+      {% endif %}
+    </div>
+  {% endif %}
 {% else %}
     <div class="dimmed light small">
       {{ "LOADING" | translate | safe }}


### PR DESCRIPTION
I really wanted a stock market table that looked like the default MMM modules like Calendar and Weather. You can merge this into this module if you like it. Otherwise feel free to close this PR.

![image](https://github.com/user-attachments/assets/4ca25559-2ac9-4088-b67e-dbfdac0b2414)
